### PR TITLE
Decoding uses inclusive Interval on lower bound

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@
 					ck = false;
 					c = c - 64;
 				}
-				if (c < 42 && c > 0) {
+				if (c < 42 && c >= 0) {
 					output.push(c + 214);
 				} else {
 					output.push(c - 42);


### PR DESCRIPTION
Hello,
I wanted to yenc some buffers and found your lib, but I found a little mistake in it. The decoding must use an inclusive lower bound, otherwise, a byte that originally has the value `214` is decoded with the value `-42`.  In a way, `-42` and `214` are kind of the same value if you are looping on *unit8* but in your case, the value is not added to a `Uint8Array` but to a generic `Array`.
It took me some hair pulling to find out, but [this Ruby alternative](https://github.com/madgeekfiend/yenc/blob/master/lib/y_enc.rb) helped me.
Cheers.
